### PR TITLE
feat: lookup client by email

### DIFF
--- a/functions/src/clients.ts
+++ b/functions/src/clients.ts
@@ -12,6 +12,24 @@ export const getClients = functions.https.onCall(async (request) => {
   return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
 });
 
+export const getClientByEmail = functions.https.onCall(async (request) => {
+  const { professionalId, email } = request.data;
+  const decoded = await authenticate(request);
+  ensureProfessional(decoded, professionalId);
+  const snap = await db
+    .collection('clients')
+    .where('professionalId', '==', professionalId)
+    .where('email', '==', email)
+    .limit(1)
+    .get();
+  if (snap.empty) {
+    throw new functions.https.HttpsError('not-found', 'Cliente no encontrado');
+  }
+  const doc = snap.docs[0];
+  const { history, ...data } = doc.data() as any;
+  return { id: doc.id, ...data };
+});
+
 export const addClient = functions.https.onCall(async (request) => {
   const { professionalId, client } = request.data;
   const decoded = await authenticate(request);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,5 +1,12 @@
 export { getAppointments, getAppointmentsForClient, addAppointment, updateAppointment, deleteAppointment, sendConfirmationEmail, createBooking } from './appointments';
-export { getClients, addClient, updateClient, deleteClient, getClientHistory } from './clients';
+export {
+  getClients,
+  getClientByEmail,
+  addClient,
+  updateClient,
+  deleteClient,
+  getClientHistory,
+} from './clients';
 export { getServices, addService, updateService, deleteService, getServiceHistory } from './services';
 export { getTimeBlocks, addTimeBlock, updateTimeBlock, deleteTimeBlock } from './timeBlocks';
 export { createInvitationCode, validateAndUseCode, getPendingInvitations } from './invitations';

--- a/functions/tests/clients.test.ts
+++ b/functions/tests/clients.test.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions';
 import {
   getClients,
+  getClientByEmail,
   addClient,
   updateClient,
   deleteClient,
@@ -48,6 +49,11 @@ describe('clients auth', () => {
       'getClientHistory',
       getClientHistory,
       { professionalId: 'p1', clientId: 'c1' },
+    ],
+    [
+      'getClientByEmail',
+      getClientByEmail,
+      { professionalId: 'p1', email: 'c1@example.com' },
     ],
   ])('%s denies mismatched professional', async (_, fn, data) => {
     await expect((fn as any).run({ ...baseReq, data })).rejects.toThrow(permError);


### PR DESCRIPTION
## Summary
- add getClientByEmail callable to retrieve a client's data excluding history
- export new function and expand test coverage for auth

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a258a2ffc48327971f4f6669deb2c9