### PR TITLE
refactor: expose client lookup

### DIFF
--- a/functions/src/clients.ts
+++ b/functions/src/clients.ts
@@ -14,8 +14,6 @@ export const getClients = functions.https.onCall(async (request) => {
 
 export const getClientByEmail = functions.https.onCall(async (request) => {
   const { professionalId, email } = request.data;
-  const decoded = await authenticate(request);
-  ensureProfessional(decoded, professionalId);
   const snap = await db
     .collection('clients')
     .where('professionalId', '==', professionalId)
@@ -26,8 +24,13 @@ export const getClientByEmail = functions.https.onCall(async (request) => {
     throw new functions.https.HttpsError('not-found', 'Cliente no encontrado');
   }
   const doc = snap.docs[0];
-  const { history, ...data } = doc.data() as any;
-  return { id: doc.id, ...data };
+  const data = doc.data() as any;
+  return {
+    id: doc.id,
+    email: data.email,
+    name: data.name,
+    phone: data.phone,
+  };
 });
 
 export const addClient = functions.https.onCall(async (request) => {


### PR DESCRIPTION
## Summary
- drop authentication requirement for getClientByEmail and limit returned fields
- adjust client auth tests and add coverage for public lookup response

## Testing
- `npm --prefix functions test`
- `npm --prefix functions run build`
- `npm --prefix functions run deploy` *(fails: firebase: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a27a51bc588327a8803c45feba408d