### PR TITLE
Validate parameters for getClientByEmail

### DIFF
--- a/functions/src/clients.ts
+++ b/functions/src/clients.ts
@@ -14,6 +14,12 @@ export const getClients = functions.https.onCall(async (request) => {
 
 export const getClientByEmail = functions.https.onCall(async (request) => {
   const { professionalId, email } = request.data;
+  if (!professionalId || !email) {
+    throw new functions.https.HttpsError(
+      'invalid-argument',
+      'professionalId y email son requeridos'
+    );
+  }
   const snap = await db
     .collection('clients')
     .where('professionalId', '==', professionalId)

--- a/functions/tests/clients.test.ts
+++ b/functions/tests/clients.test.ts
@@ -88,4 +88,19 @@ describe('getClientByEmail', () => {
     });
     collectionSpy.mockRestore();
   });
+
+  it('requires professionalId and email', async () => {
+    await expect(
+      (getClientByEmail as any).run({
+        data: { professionalId: 'p1' },
+        rawRequest: {},
+      })
+    ).rejects.toThrow('professionalId y email son requeridos');
+    await expect(
+      (getClientByEmail as any).run({
+        data: { email: 'c1@example.com' },
+        rawRequest: {},
+      })
+    ).rejects.toThrow('professionalId y email son requeridos');
+  });
 });


### PR DESCRIPTION
## Summary
- ensure getClientByEmail requires professionalId and email
- add tests covering missing parameters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a27dd2a08483279dd4983abbc6c4d2