### PR TITLE
Filter cancelled appointments from availability

### DIFF
--- a/functions/src/availabilityCacheCleanup.ts
+++ b/functions/src/availabilityCacheCleanup.ts
@@ -1,0 +1,18 @@
+import * as functions from 'firebase-functions';
+import { Timestamp } from 'firebase-admin/firestore';
+import { db } from './utils';
+
+export const cleanAvailabilityCache = functions.pubsub
+  .schedule('every 24 hours')
+  .onRun(async () => {
+    const cutoff = Timestamp.fromDate(
+      new Date(Date.now() - 24 * 60 * 60 * 1000)
+    );
+    const snapshot = await db
+      .collection('availabilityCache')
+      .where('createdAt', '<', cutoff)
+      .get();
+    const batch = db.batch();
+    snapshot.forEach(doc => batch.delete(doc.ref));
+    await batch.commit();
+  });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,4 +1,15 @@
-export { getAppointments, getAppointmentsForClient, addAppointment, updateAppointment, deleteAppointment, sendConfirmationEmail, createBooking } from './appointments';
+import * as functions from 'firebase-functions';
+import { availability as availabilityHandler } from './availability';
+
+export {
+  getAppointments,
+  getAppointmentsForClient,
+  addAppointment,
+  updateAppointment,
+  deleteAppointment,
+  sendConfirmationEmail,
+  createBooking,
+} from './appointments';
 export {
   getClients,
   getClientByEmail,
@@ -12,4 +23,11 @@ export { getTimeBlocks, addTimeBlock, updateTimeBlock, deleteTimeBlock } from '.
 export { createInvitationCode, validateAndUseCode, getPendingInvitations } from './invitations';
 export { inviteNewUser, getTeamMembers, updateMemberRole, deleteTeamMember } from './team';
 export { getProfessionalProfile, updateWorkSchedule, updateProfile } from './settings';
-export { availability } from './availability';
+
+export const availability = functions
+  .region('southamerica-east1')
+  .runWith({ minInstances: 1, memory: '256MB' })
+  .https.onCall(availabilityHandler);
+
+export { cleanAvailabilityCache } from './availabilityCacheCleanup';
+

--- a/functions/tests/availability.test.ts
+++ b/functions/tests/availability.test.ts
@@ -10,6 +10,9 @@ import { db } from '../src/utils';
 describe('availability', () => {
   let professionalData: any;
   let serviceData: any;
+  let availabilityCache: Record<string, any>;
+  let appointmentsGetMock: jest.Mock;
+  let timeBlocksGetMock: jest.Mock;
 
   beforeEach(() => {
     jest.useFakeTimers().setSystemTime(new Date('2024-01-01T10:00:00Z'));
@@ -22,6 +25,9 @@ describe('availability', () => {
       },
     };
     serviceData = { duration: 30 };
+    availabilityCache = {};
+    appointmentsGetMock = jest.fn().mockResolvedValue({ docs: [] });
+    timeBlocksGetMock = jest.fn().mockResolvedValue({ docs: [] });
     (db.collection as jest.Mock).mockImplementation((name: string) => {
       if (name === 'professionals') {
         return {
@@ -29,7 +35,7 @@ describe('availability', () => {
             get: () =>
               Promise.resolve({
                 exists: true,
-data: () => professionalData,
+                data: () => professionalData,
               }),
           }),
         } as any;
@@ -40,13 +46,45 @@ data: () => professionalData,
             get: () =>
               Promise.resolve({
                 exists: true,
-data: () => serviceData,
+                data: () => serviceData,
               }),
           }),
         } as any;
       }
+      if (name === 'availabilityCache') {
+        return {
+          doc: (id: string) => ({
+            get: jest.fn(() =>
+              Promise.resolve(
+                availabilityCache[id]
+                  ? { exists: true, data: () => availabilityCache[id] }
+                  : { exists: false }
+              )
+            ),
+            set: jest.fn((data: any) => {
+              availabilityCache[id] = data;
+              return Promise.resolve();
+            }),
+          }),
+        } as any;
+      }
+      if (name === 'appointments') {
+        return {
+          where: jest.fn().mockReturnThis(),
+          select: jest.fn().mockReturnThis(),
+          get: appointmentsGetMock,
+        } as any;
+      }
+      if (name === 'timeBlocks') {
+        return {
+          where: jest.fn().mockReturnThis(),
+          select: jest.fn().mockReturnThis(),
+          get: timeBlocksGetMock,
+        } as any;
+      }
       return {
         where: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
         get: jest.fn().mockResolvedValue({ docs: [] }),
       } as any;
     });
@@ -59,9 +97,9 @@ data: () => serviceData,
 
   it('returns slots later than now for current day', async () => {
     const date = new Date('2024-01-01T00:00:00Z');
-    const result = await (availability as any).run({
+    const result = await availability({
       data: { date: date.toISOString(), professionalId: 'p1', serviceId: 's1' },
-    });
+    } as any);
     expect(result).toContain('2024-01-01T10:15:00.000Z');
   });
 
@@ -72,10 +110,23 @@ data: () => serviceData,
       end: '03:00',
     };
     const date = new Date('2024-01-01T08:00:00Z');
-    const result = await (availability as any).run({
+    const result = await availability({
       data: { date: date.toISOString(), professionalId: 'p1', serviceId: 's1' },
-    });
+    } as any);
     expect(result).toContain('2024-01-01T10:15:00.000Z');
     expect(result).not.toContain('2024-01-01T08:00:00.000Z');
+  });
+
+  it('returns cached availability when present', async () => {
+    availabilityCache['p1_s1_2024-01-01'] = {
+      slots: ['2024-01-01T12:00:00.000Z'],
+    };
+    const date = new Date('2024-01-01T00:00:00Z');
+    const result = await availability({
+      data: { date: date.toISOString(), professionalId: 'p1', serviceId: 's1' },
+    } as any);
+    expect(result).toEqual(['2024-01-01T12:00:00.000Z']);
+    expect(appointmentsGetMock).not.toHaveBeenCalled();
+    expect(timeBlocksGetMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- cache availability results in Firestore for repeated lookups
- schedule daily cleanup of stale availability cache documents
- extend availability tests to cover new cache behavior
- exclude cancelled appointments and limit queries to start/end fields
- scan sorted existing events with a sliding index to skip past overlaps
- host `availability` in `southamerica-east1` with 256MB memory and a warm instance

## Testing
- `npm test --prefix functions`
- `npm run lint --prefix functions`


------
https://chatgpt.com/codex/tasks/task_e_68b3213b8b6083279e252bd348abd7bb