### PR TITLE
chore: set minInstances to zero

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2,7 +2,7 @@ import { setGlobalOptions } from 'firebase-functions/v2';
 import { onCall } from 'firebase-functions/v2/https';
 import { availability as availabilityHandler } from './availability';
 
-setGlobalOptions({ region: 'southamerica-east1', memory: '256MiB', minInstances: 1 });
+setGlobalOptions({ region: 'southamerica-east1', memory: '256MiB', minInstances: 0 });
 export {
   getAppointments,
   getAppointmentsForClient,


### PR DESCRIPTION
## Summary
- set Cloud Functions minInstances to zero for southamerica-east1

## Testing
- `npm test --prefix functions`
- `npm run build --prefix functions`
- `firebase deploy --only functions:availability --gen2` *(fails: unknown option '--gen2'; deployment subsequently failed to authenticate)*

------
https://chatgpt.com/codex/tasks/task_e_68b7045b943883279d4d6e7711cb740e